### PR TITLE
CAP homepage + core governance docs

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,23 @@
+name: link-check
+on:
+  schedule: [ { cron: '0 7 1 * *' } ]
+  workflow_dispatch:
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress --max-redirects 10 './**/*.md' './**/*.html'
+      - name: Save report
+        if: always()
+        run: |
+          mkdir -p reports
+          cp ./lychee/out.md reports/link-check.md || true
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-check-report
+          path: reports/link-check.md

--- a/docs/CHARTER.md
+++ b/docs/CHARTER.md
@@ -1,0 +1,5 @@
+# CAP Charter
+
+**Mission:** Neutral, public-interest governance for hybrid society in the AI era.  
+**Scope:** Field experiments, open toolkits, audits, and education that improve civic capacity under accelerating AI.  
+**Red-lines:** No partisan campaigning; no surveillance tooling; no discriminatory deployments; no donor roadmap control.

--- a/docs/COVENANT.md
+++ b/docs/COVENANT.md
@@ -1,0 +1,9 @@
+# Non-Interference Covenant
+
+1. No feature/roadmap control by funders.  
+2. Open results by default (privacy/security exceptions documented).  
+3. Single-funder cap ≤ 35% of annual budget.  
+4. Conflict-of-interest recusal.  
+5. Transparency: donors, amounts, minutes ≤ 30 days.  
+6. Mission-lock veto (Steward).  
+7. Independent process review as fail-safe (pre-named panel).

--- a/docs/SEQUENCING.md
+++ b/docs/SEQUENCING.md
@@ -1,0 +1,6 @@
+# Public Plan (Sequencing)
+
+**Phase 1:** Whisper launch (site + charter + covenant).  
+**Phase 2:** Private invites to exemplar funders; soft public launch.  
+**Phase 3:** Pilots: CoCivium v1 + HSP research stream; publish rubrics.  
+**Phase 4:** Annual report, audits, and **RepTag/CoPops** awards.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,0 +1,7 @@
+# Proposed Structure
+
+- **Founders Council (non-voting advisory):** 1 delegate per founding funder; cannot direct product.  
+- **Mission Steward:** agenda + mission-lock; **no vote** on grants to own program.  
+- **Independent Grants Committee:** rotating, conflict-screened, approves disbursements.  
+- **Secretariat (tiny):** compliance, minutes, transparency.  
+- **Chair:** rotating every 6 months (no permanent chair).

--- a/index.html
+++ b/index.html
@@ -1,3 +1,50 @@
-<!doctype html><meta charset="utf-8"><title>CoPolitic.org</title>
-<h1>Civic Alignment Protectorate (CAP)</h1>
-<p>Proposed neutral canopy for hybrid-society governance.</p>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Civic Alignment Protectorate (CAP) — CoPolitic.org</title>
+<link rel="canonical" href="https://copolitic.org/"/>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900">
+<header class="max-w-6xl mx-auto px-6 py-12">
+  <h1 class="text-4xl md:text-5xl font-bold">Civic Alignment Protectorate (CAP)</h1>
+  <p class="mt-4 text-lg max-w-3xl">
+    A neutral, public-interest canopy for hybrid-society governance in the AI era. Advisory, not controlling. Transparent, not partisan.
+  </p>
+  <div class="mt-6 flex flex-wrap gap-4 text-blue-700 underline">
+    <a href="/docs/CHARTER.md">Charter</a>
+    <a href="/docs/COVENANT.md">Non-Interference Covenant</a>
+    <a href="/docs/STRUCTURE.md">Proposed Structure</a>
+    <a href="/docs/SEQUENCING.md">Public Plan</a>
+    <a href="/initiatives/README.md">Initiatives</a>
+    <a href="/pitch/">Pitch</a>
+    <a href="/transparency/">Transparency</a>
+  </div>
+</header>
+
+<main class="max-w-6xl mx-auto px-6 pb-20">
+  <section class="mt-6">
+    <h2 class="text-2xl font-semibold">Exemplar Advocates (independent actors we admire)</h2>
+    <p class="text-gray-700 mt-1">Listed as exemplars; not partners or members. Linked only to official sources.</p>
+    <ul class="list-disc pl-6 mt-3 space-y-1">
+      <li><a class="underline" href="https://survivalandflourishing.fund/">Survival & Flourishing Fund (SFF)</a></li>
+      <li><a class="underline" href="https://alignment.dev/">Alignment Research Center (ARC)</a></li>
+      <li><a class="underline" href="https://openai.com/">OpenAI (nonprofit mission)</a></li>
+      <li><a class="underline" href="https://www.opensocietyfoundations.org/">Open Society Foundations (OSF)</a></li>
+    </ul>
+  </section>
+
+  <section class="mt-10">
+    <h2 class="text-2xl font-semibold">Link Integrity</h2>
+    <p class="text-gray-700 mt-1">We run a monthly link-check and publish results; broken links get repaired or archived.</p>
+    <img src="https://img.shields.io/badge/link%20health-scheduled-blue" alt="Link Health badge"/>
+  </section>
+</main>
+
+<footer class="border-t">
+  <div class="max-w-6xl mx-auto px-6 py-6 text-sm text-gray-600">
+    © CAP at CoPolitic.org — <em>Proposed structure</em>; advisory, not controlling. Neutrality policy in the
+    <a class="underline" href="/docs/COVENANT.md">Covenant</a>.
+  </div>
+</footer>
+</body></html>

--- a/initiatives/README.md
+++ b/initiatives/README.md
@@ -1,0 +1,5 @@
+# CAP Initiatives (Pipeline)
+
+- **RepTag / CoPops (Awards)** — credibility rubric + annual ceremony. *Status:* concept.  
+- **GroupBuild.org (Advocacy Organizer)** — non-partisan civic mobilization tool. *Status:* concept.  
+- **HSP (Hybrid Society Program)** — research stream under CAP. *Status:* concept.

--- a/pitch/README.md
+++ b/pitch/README.md
@@ -1,0 +1,1 @@
+Public pitch lives here (2-pager + 10-slide deck).

--- a/transparency/README.md
+++ b/transparency/README.md
@@ -1,0 +1,1 @@
+Donor disclosure, minutes (≤30 days), annual report, link-health summary.


### PR DESCRIPTION
Adds hero homepage, Charter/Covenant/Structure/Sequencing, and monthly link-check workflow.