### PR TITLE
Exemplar funder case-notes (SFF, ARC, OpenAI, OSF)

### DIFF
--- a/funders/ARC.md
+++ b/funders/ARC.md
@@ -1,0 +1,4 @@
+# Alignment Research Center (ARC)
+**Why exemplar:** Conducts foundational alignment research and supports evaluations/red-teaming.
+**Official:** https://alignment.dev/
+**Notes:** Values empirical tests and field feedback loops—congruent with CAP’s pilot ethos.

--- a/funders/OSF.md
+++ b/funders/OSF.md
@@ -1,0 +1,4 @@
+# Open Society Foundations (OSF)
+**Why exemplar:** Longstanding support for democratic resilience, transparency, and rights.
+**Official:** https://www.opensocietyfoundations.org/
+**Notes:** Listed as exemplar; does not imply partnership or endorsement.

--- a/funders/OpenAI.md
+++ b/funders/OpenAI.md
@@ -1,0 +1,4 @@
+# OpenAI (nonprofit mission)
+**Why exemplar:** “Benefit all of humanity” mandate; invests in safety, governance, and public-interest tooling.
+**Official:** https://openai.com/
+**Notes:** Interest in governance pilots and public education aligns with CAP’s neutrality & transparency.

--- a/funders/SFF.md
+++ b/funders/SFF.md
@@ -1,0 +1,4 @@
+# Survival & Flourishing Fund (SFF)
+**Why exemplar:** Deploys flexible grants to reduce existential risk and strengthen human flourishing.
+**Official:** https://survivalandflourishing.fund/
+**Notes:** Known for fast, minimally prescriptive support to high-leverage civic/AI safety work.

--- a/index.html
+++ b/index.html
@@ -31,8 +31,12 @@
       <li><a class="underline" href="https://alignment.dev/">Alignment Research Center (ARC)</a></li>
       <li><a class="underline" href="https://openai.com/">OpenAI (nonprofit mission)</a></li>
       <li><a class="underline" href="https://www.opensocietyfoundations.org/">Open Society Foundations (OSF)</a></li>
-    </ul>
-  </section>
+      <li><a class=""underline"" href=""/funders/SFF.md"">SFF — case note</a></li>
+  <li><a class=""underline"" href=""/funders/ARC.md"">ARC — case note</a></li>
+  <li><a class=""underline"" href=""/funders/OpenAI.md"">OpenAI — case note</a></li>
+  <li><a class=""underline"" href=""/funders/OSF.md"">OSF — case note</a></li>
+</ul>
+</section>
 
   <section class="mt-10">
     <h2 class="text-2xl font-semibold">Link Integrity</h2>
@@ -48,3 +52,4 @@
   </div>
 </footer>
 </body></html>
+


### PR DESCRIPTION
Adds neutral case-note pages under /funders and links from homepage. Exemplar ≠ affiliation.