### PR TITLE
fix: exemplar neutrality callout

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Page not found — CoPolitic.org</title>
+<link rel="canonical" href="https://copolitic.org/">
+<script src="https://cdn.tailwindcss.com"></script>
+<body class="min-h-screen grid place-items-center bg-white text-gray-900">
+  <main class="text-center p-6">
+    <h1 class="text-5xl font-bold">404</h1>
+    <p class="mt-2 text-lg">We couldn’t find that page.</p>
+    <p class="mt-4"><a class="underline text-blue-700" href="/">Back to home</a></p>
+  </main>
+</body>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+# Code of Conduct
+Be respectful. No harassment. Disagree on ideas without attacking people.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+- Open a PR; all changes go through review.
+- Keep exemplars neutral (no implied affiliation).
+- Link to official sources only.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+MIT License — see https://choosealicense.com/licenses/mit/

--- a/index.html
+++ b/index.html
@@ -13,15 +13,22 @@
   <meta name="twitter:title" content="Civic Alignment Protectorate (CAP) — CoPolitic.org" />
   <meta name="twitter:description" content="A neutral, public-interest canopy for hybrid-society governance." />
   <meta name="twitter:image" content="https://copolitic.org/assets/img/copolitic_hero.webp" />
+  <meta name="description" content="A neutral, public-interest canopy for hybrid-society governance in the AI era. Advisory, not controlling. Transparent, not partisan." />
+  <meta name="theme-color" content="#0f172a" />
 </head>
-<body class="bg-white text-gray-900">
-<img src="/assets/img/copolitic_hero.webp" alt="Civic Alignment Protectorate — hero" class="w-full h-auto max-h-[520px] object-cover"/>
+<body class="bg-white text-gray-900"><a id="skip" href="#main" class="sr-only focus:not-sr-only underline px-3 py-2">Skip to content</a>
+<picture>
+  <source srcset="/assets/img/copolitic_hero.webp" type="image/webp" />
+  <img src="/assets/img/copolitic_hero.png" alt="Neutral roundtable discussing civic governance and AI"
+       class="w-full h-auto max-h-[420px] md:max-h-[520px] object-cover"
+       width="1600" height="900" />
+</picture>
 <header class="max-w-6xl mx-auto px-6 py-12">
   <h1 class="text-4xl md:text-5xl font-bold">Civic Alignment Protectorate (CAP)</h1>
   <p class="mt-4 text-lg max-w-3xl">
     A neutral, public-interest canopy for hybrid-society governance in the AI era. Advisory, not controlling. Transparent, not partisan.
   </p>
-  <div class="mt-6 flex flex-wrap gap-4 text-blue-700 underline">
+  <nav class="mt-6 flex flex-wrap gap-4 text-blue-700 underline" aria-label="Primary">
     <a href="/docs/CHARTER.md">Charter</a>
     <a href="/docs/COVENANT.md">Non-Interference Covenant</a>
     <a href="/docs/STRUCTURE.md">Proposed Structure</a>
@@ -29,22 +36,25 @@
     <a href="/initiatives/README.md">Initiatives</a>
     <a href="/pitch/">Pitch</a>
     <a href="/transparency/">Transparency</a>
-  </div>
-</header>
+  </nav></header>
 
-<main class="max-w-6xl mx-auto px-6 pb-20">
+<main id="main" class="max-w-6xl mx-auto px-6 pb-20">
   <section class="mt-6">
     <h2 class="text-2xl font-semibold">Exemplar Advocates (independent actors we admire)</h2>
     <p class="text-gray-700 mt-1">Listed as exemplars; not partners or members. Linked only to official sources.</p>
     <ul class="list-disc pl-6 mt-3 space-y-1">
-      <li><a class="underline" href="https://survivalandflourishing.fund/">Survival & Flourishing Fund (SFF)</a></li>
-      <li><a class="underline" href="https://alignment.dev/">Alignment Research Center (ARC)</a></li>
-      <li><a class="underline" href="https://openai.com/">OpenAI (nonprofit mission)</a></li>
-      <li><a class="underline" href="https://www.opensocietyfoundations.org/">Open Society Foundations (OSF)</a></li>
-      <li><a class=""underline"" href=""/funders/SFF.md"">SFF — case note</a></li>
-  <li><a class=""underline"" href=""/funders/ARC.md"">ARC — case note</a></li>
-  <li><a class=""underline"" href=""/funders/OpenAI.md"">OpenAI — case note</a></li>
-  <li><a class=""underline"" href=""/funders/OSF.md"">OSF — case note</a></li>
+  <li> <a class="underline" href="https://survivalandflourishing.fund/">Survival & Flourishing Fund (SFF)</a>
+       <ul class="list-disc pl-6"><li><a class="underline" href="/funders/SFF.md">SFF — case note</a></li></ul>
+  </li>
+  <li> <a class="underline" href="https://alignment.dev/">Alignment Research Center (ARC)</a>
+       <ul class="list-disc pl-6"><li><a class="underline" href="/funders/ARC.md">ARC — case note</a></li></ul>
+  </li>
+  <li> <a class="underline" href="https://openai.com/">OpenAI (nonprofit mission)</a>
+       <ul class="list-disc pl-6"><li><a class="underline" href="/funders/OpenAI.md">OpenAI — case note</a></li></ul>
+  </li>
+  <li> <a class="underline" href="https://www.opensocietyfoundations.org/">Open Society Foundations (OSF)</a>
+       <ul class="list-disc pl-6"><li><a class="underline" href="/funders/OSF.md">OSF — case note</a></li></ul>
+  </li>
 </ul>
 </section>
 
@@ -57,11 +67,14 @@
 
 <footer class="border-t">
   <div class="max-w-6xl mx-auto px-6 py-6 text-sm text-gray-600">
-    © CAP at CoPolitic.org — <em>Proposed structure</em>; advisory, not controlling. Neutrality policy in the
+    © CAP at CoPolitic.org — <em>Proposed structure</em>; advisory, not controlling. Contact: <a class="underline" href="mailto:info@copolitic.org">info@copolitic.org</a>. Neutrality policy in the
     <a class="underline" href="/docs/COVENANT.md">Covenant</a>.
   </div>
 </footer>
 </body></html>
+
+
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
 <title>Civic Alignment Protectorate (CAP) — CoPolitic.org</title>
 <link rel="canonical" href="https://copolitic.org/"/>
 <script src="https://cdn.tailwindcss.com"></script>
+  <meta property="og:title" content="Civic Alignment Protectorate (CAP) — CoPolitic.org" />
+  <meta property="og:description" content="A neutral, public-interest canopy for hybrid-society governance." />
+  <meta property="og:image" content="https://copolitic.org/assets/img/copolitic_hero.webp" />
+  <meta property="og:url" content="https://copolitic.org/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Civic Alignment Protectorate (CAP) — CoPolitic.org" />
+  <meta name="twitter:description" content="A neutral, public-interest canopy for hybrid-society governance." />
+  <meta name="twitter:image" content="https://copolitic.org/assets/img/copolitic_hero.webp" />
 </head>
 <body class="bg-white text-gray-900">
 <img src="/assets/img/copolitic_hero.webp" alt="Civic Alignment Protectorate — hero" class="w-full h-auto max-h-[520px] object-cover"/>
@@ -53,6 +62,7 @@
   </div>
 </footer>
 </body></html>
+
 
 
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://copolitic.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+ <url><loc>https://copolitic.org/</loc></url>
+ <url><loc>https://copolitic.org/docs/CHARTER.md</loc></url>
+ <url><loc>https://copolitic.org/docs/COVENANT.md</loc></url>
+ <url><loc>https://copolitic.org/docs/STRUCTURE.md</loc></url>
+ <url><loc>https://copolitic.org/docs/SEQUENCING.md</loc></url>
+ <url><loc>https://copolitic.org/initiatives/README.md</loc></url>
+ <url><loc>https://copolitic.org/funders/SFF.md</loc></url>
+ <url><loc>https://copolitic.org/funders/ARC.md</loc></url>
+ <url><loc>https://copolitic.org/funders/OpenAI.md</loc></url>
+ <url><loc>https://copolitic.org/funders/OSF.md</loc></url>
+</urlset>


### PR DESCRIPTION
Adds the blue clarifying note above the Exemplars list.